### PR TITLE
Move fetch into try/catch to catch errors during download

### DIFF
--- a/Instagrizzle/Instagrizzle.php
+++ b/Instagrizzle/Instagrizzle.php
@@ -45,10 +45,10 @@ class Instagrizzle
 
     private function getFeed()
     {
-        $html = file_get_contents("https://www.instagram.com/{$this->username}");
-        $re = '/window\._sharedData = {(.*)}/';
-
         try {
+            $html = file_get_contents("https://www.instagram.com/{$this->username}");
+            $re = '/window\._sharedData = {(.*)}/';
+
             preg_match_all($re, $html, $matches, PREG_SET_ORDER, 0);
             $json = json_decode('{' . $matches[0][1] . '}', true);
             $profile = $json['entry_data']['ProfilePage'][0]['graphql']['user'];

--- a/Instagrizzle/Instagrizzle.php
+++ b/Instagrizzle/Instagrizzle.php
@@ -26,8 +26,13 @@ class Instagrizzle
     {
         // Grab media from cache if available
         if (!$media = $this->cache->get($this->username)) {
-            // Otherwise, get the feed from Instagram
-            $media = $this->getFeed()->toArray();
+            try {
+                // Otherwise, get the feed from Instagram
+                $media = $this->getFeed()->toArray();
+            } catch (\Exception $exception) {
+                return [];
+            }
+
             // Save it to the cache for next time (defaults to 1 hour)
             $this->cache->put($this->username, $media, $this->getConfig('cache_length', 60));
         }
@@ -45,25 +50,20 @@ class Instagrizzle
 
     private function getFeed()
     {
-        try {
-            $html = file_get_contents("https://www.instagram.com/{$this->username}");
-            $re = '/window\._sharedData = {(.*)}/';
+        $html = file_get_contents("https://www.instagram.com/{$this->username}");
+        $re = '/window\._sharedData = {(.*)}/';
 
-            preg_match_all($re, $html, $matches, PREG_SET_ORDER, 0);
-            $json = json_decode('{' . $matches[0][1] . '}', true);
-            $profile = $json['entry_data']['ProfilePage'][0]['graphql']['user'];
-            $media = $profile['edge_owner_to_timeline_media']['edges'];
+        preg_match_all($re, $html, $matches, PREG_SET_ORDER, 0);
+        $json = json_decode('{' . $matches[0][1] . '}', true);
+        $profile = $json['entry_data']['ProfilePage'][0]['graphql']['user'];
+        $media = $profile['edge_owner_to_timeline_media']['edges'];
 
-            return collect($media)->map(function ($item) {
-                return array_merge($item['node'], [
-                    'link' => 'https://www.instagram.com/p/' . $item['node']['shortcode'],
-                    'thumbnail' => $item['node']['thumbnail_src'],
-                    'image' => $item['node']['display_url'],
-                ]);
-            });
-        } catch (\Exception $e) {
-        }
-
-        return collect();
+        return collect($media)->map(function ($item) {
+            return array_merge($item['node'], [
+                'link' => 'https://www.instagram.com/p/' . $item['node']['shortcode'],
+                'thumbnail' => $item['node']['thumbnail_src'],
+                'image' => $item['node']['display_url'],
+            ]);
+        });
     }
 }


### PR DESCRIPTION
When the download of the instragram feed fails the plugins throws an unhandled exception and the page breaks.

```
#0 [internal function]: Illuminate\Foundation\Bootstrap\HandleExceptions->handleError(2, 'file_get_conten...', '/srv/users/serv...', 48, Array)
#1 /srv/users/serverpilot/apps/beautylounge/site/addons/Instagrizzle/Instagrizzle.php(48): file_get_contents('https://www.ins...')
#2 /srv/users/serverpilot/apps/beautylounge/site/addons/Instagrizzle/Instagrizzle.php(30): Statamic\Addons\Instagrizzle\Instagrizzle->getFeed()
```

Moving the `file_get_contents` into the try/catch handles this exception and falls back to the empty feed.